### PR TITLE
Add rapid uploader

### DIFF
--- a/docs/en/02_RapidUploader/00_Example_Rapid_Uploader.md
+++ b/docs/en/02_RapidUploader/00_Example_Rapid_Uploader.md
@@ -1,0 +1,66 @@
+---
+title: Example implementation for a rapid uploader
+---
+
+In some circumstances it may be desirable to allow CMS users to rapidly populate content by uploading files. You can use this module to handle additional actions after a file as been uploaded. For this example we will create a basic form controller that extends from LeftAndMain and has a PerfectCmsImagesUploadField.
+
+```php
+<?php
+
+use SilverStripe\Admin\LeftAndMain;
+use SilverStripe\Control\HTTPResponse;
+use SilverStripe\Forms\FieldList;
+use SilverStripe\Forms\Form;
+
+use Sunnysideup\PerfectCmsImages\Forms\PerfectCmsImagesUploadField;
+
+use \CarouselItem;
+
+class RapidUploader extends LeftAndMain
+{
+    private static $url_segment     = 'uploader-carousel/add';
+    private static $ignore_menuitem = true;
+
+    private static $allowed_actions = [
+        'EmptyForm',
+    ];
+
+    /**
+     * @return Form
+     */
+    public function EmptyForm()
+    {
+        return Form::create(
+            $this,
+            "EditForm",
+            FieldList::create([
+                PerfectCmsImagesUploadField::create('AttachedFile')
+                    ->setIsMultiUpload(true)
+                    ->setAfterUpload(function(HTTPResponse $response) {
+                        // Read data from the original response
+                        $data = json_decode($response->getBody())[0];
+
+                        // Create a new CarouselItem
+                        $x = CarouselItem::create();
+
+                        // Set the BackgroundImage to the uploaded file
+                        $x->BackgroundImageID = $data->id;
+
+                        // preg the Title/SubTitle from the title of the file
+                        $title = preg_split('[/.---]', $data->title, PREG_SPLIT_OFFSET_CAPTURE);
+                        $x->Title = $title[0];
+                        if(isset($title[1])) { $x->SubTitle = $title[1]; }
+
+                        // Write the CarouselItem
+                        $x->write();
+
+                        // Return the original response (untouched)
+                        return $response;
+                    })
+            ])
+        );
+    }
+}
+```
+
+This is just an example but could easily be extended to read additional metadata from the file for populating as separate fields in the CMS.

--- a/src/Api/PerfectCMSImages.php
+++ b/src/Api/PerfectCMSImages.php
@@ -2,11 +2,16 @@
 
 namespace Sunnysideup\PerfectCmsImages\Api;
 
+use SilverStripe\Dev\Debug;
+
+use Psr\Log\LoggerInterface;
 use SilverStripe\Assets\Filesystem;
 use SilverStripe\Assets\Folder;
 use SilverStripe\Assets\Image;
 use SilverStripe\Core\Config\Config;
 use SilverStripe\Core\Flushable;
+use SilverStripe\Core\Injector\Injector;
+use SilverStripe\Security\Security;
 use Sunnysideup\PerfectCmsImages\Model\File\PerfectCmsImageDataExtension;
 
 class PerfectCMSImages implements Flushable
@@ -352,15 +357,11 @@ EOT;
     protected static function get_one_value_for_image(string $name, string $key, ?string $default = '')
     {
         $sizes = self::get_all_values_for_images();
-        //print_r($sizes);die();
-        if (isset($sizes[$name])) {
-            if (isset($sizes[$name][$key])) {
-                return $sizes[$name][$key];
-            }
+        if (isset($sizes[$name]) && isset($sizes[$name][$key])) {
+            return $sizes[$name][$key];
         } else {
-            user_error('no information for image with name: ' . $name);
+            Injector::inst()->get(LoggerInterface::class)->info('no information for image with the name: ' . $name);
         }
-
         return $default;
     }
 
@@ -369,6 +370,9 @@ EOT;
      */
     protected static function get_all_values_for_images(): array
     {
-        return Config::inst()->get(PerfectCmsImageDataExtension::class, 'perfect_cms_images_image_definitions');
+        return Config::inst()->get(
+            PerfectCmsImageDataExtension::class,
+            'perfect_cms_images_image_definitions'
+        ) ?: [];
     }
 }

--- a/src/Forms/PerfectCmsImagesUploadField.php
+++ b/src/Forms/PerfectCmsImagesUploadField.php
@@ -2,16 +2,20 @@
 
 namespace Sunnysideup\PerfectCmsImages\Forms;
 
+use SilverStripe\Dev\Debug;
+
 use SilverStripe\AssetAdmin\Forms\UploadField;
 use SilverStripe\Assets\Folder;
-use SilverStripe\ORM\FieldType\DBField;
+use SilverStripe\Control\HTTPRequest;
+use SilverStripe\Control\HTTPResponse;
 use SilverStripe\ORM\SS_List;
+use SilverStripe\ORM\FieldType\DBField;
 use Sunnysideup\PerfectCmsImages\Api\PerfectCMSImages;
 use Sunnysideup\PerfectCmsImages\Filesystem\PerfectCmsImageValidator;
 
 /**
  * image-friendly upload field.
-
+ *
  * Usage:
  *     $field = PerfectCmsImagesUploadFielde::create(
  *         "ImageField",
@@ -26,16 +30,14 @@ class PerfectCmsImagesUploadField extends UploadField
     private static $folder_prefix = '';
 
     /**
-     * @param string  $name
-     * @param string  $title
+     * @param string $name The internal field name, passed to forms.
+     * @param string $title The field label.
      * @param SS_List|null $items If no items are defined, the field will try to auto-detect an existing relation
      * @param string|null $alternativeName
-     *
-     * @return UploadField
      */
     public function __construct(
         $name,
-        $title,
+        $title = null,
         SS_List $items = null,
         $alternativeName = null
     ) {
@@ -52,9 +54,9 @@ class PerfectCmsImagesUploadField extends UploadField
         $this->selectFormattingStandard($alternativeName);
     }
 
-    public function setDescription($string)
+    public function setRightTitle($string)
     {
-        parent::setDescription(
+        parent::setRightTitle(
             DBField::create_field('HTMLText', $string . '<br />' . $this->RightTitle())
         );
         //important!
@@ -69,7 +71,7 @@ class PerfectCmsImagesUploadField extends UploadField
     {
         $this->setPerfectFolderName($name);
 
-        $this->setDescription(PerfectCMSImages::get_description_for_cms($name));
+        $this->setRightTitle(PerfectCMSImages::get_description_for_cms($name));
 
         $this->setAllowedFileCategories('image');
         $alreadyAllowed = $this->getAllowedExtensions();

--- a/src/Forms/PerfectCmsImagesUploadField.php
+++ b/src/Forms/PerfectCmsImagesUploadField.php
@@ -30,6 +30,16 @@ class PerfectCmsImagesUploadField extends UploadField
     private static $folder_prefix = '';
 
     /**
+     * @config
+     * @var array
+     */
+    private static $allowed_actions = [
+        'upload'
+    ];
+
+    private $afterUpload = null;
+
+    /**
      * @param string $name The internal field name, passed to forms.
      * @param string $title The field label.
      * @param SS_List|null $items If no items are defined, the field will try to auto-detect an existing relation
@@ -103,5 +113,35 @@ class PerfectCmsImagesUploadField extends UploadField
         Folder::find_or_make($folderName);
         //set folder
         $this->setFolderName($folderName);
+    }
+
+    /**
+     * Creates a single file based on a form-urlencoded upload.
+     * Allows for hooking AfterUpload
+     *
+     * @param HTTPRequest $request
+     * @return HTTPResponse
+     */
+    public function upload(HTTPRequest $request)
+    {
+        $response = parent::upload($request);
+
+        // If afterUpload is a function ..
+        return (is_callable($this->afterUpload)) ?
+            //  .. then return the results from that ..
+            ($this->afterUpload)($response) :
+            //  .. else return the original $response
+            $response;
+    }
+
+    /**
+     * Add an anonymous functions to run after upload completes
+     *
+     * @param $func
+     * @return $this
+     */
+    public function setAfterUpload($func) {
+        $this->afterUpload = $func;
+        return $this;
     }
 }

--- a/src/Model/File/PerfectCmsImageDataExtension.php
+++ b/src/Model/File/PerfectCmsImageDataExtension.php
@@ -5,9 +5,9 @@ namespace Sunnysideup\PerfectCmsImages\Model\File;
 use SilverStripe\Assets\Image;
 use SilverStripe\Control\Director;
 use SilverStripe\Core\Convert;
+use SilverStripe\View\ArrayData;
 use SilverStripe\ORM\DataExtension;
 use SilverStripe\ORM\FieldType\DBField;
-use SilverStripe\View\ArrayData;
 use Sunnysideup\PerfectCmsImages\Api\ImageManipulations;
 use Sunnysideup\PerfectCmsImages\Api\PerfectCMSImages;
 
@@ -15,11 +15,11 @@ use Sunnysideup\PerfectCmsImages\Api\PerfectCMSImages;
  * defines the image sizes
  * and default upload folder.
  */
-
 class PerfectCmsImageDataExtension extends DataExtension
 {
+
     private static $casting = [
-        'PerfectCMSImageTag' => 'HTMLText',
+        'PerfectCMSImageTag' => 'HTMLText'
     ];
 
     /**


### PR DESCRIPTION
To fix https://github.com/sunnysideup/silverstripe-perfect_cms_images/issues/3 I have added an option for processing files *after* they have been uploaded. This allows for actions to happen in the background while the user continues to upload files.

I have created an example implementation that creates a controller in the CMS for users to simply upload files and use the filename to create new DataObjects.